### PR TITLE
release-notes-0.1.md: fix typo: not recommended to run t̶o̶ this version

### DIFF
--- a/doc/bASICKcoin-release-notes/release-notes-0.1.md
+++ b/doc/bASICKcoin-release-notes/release-notes-0.1.md
@@ -3,7 +3,7 @@ bASICKcoin Core version 0.1 is now available from:
   <TBD>
 
 This is a buggy prototype version release, bringing new bugs and less features.
-It is not recommended to run to this version.
+It is not recommended to run this version.
 
 Please report bugs using the issue tracker at github:
 


### PR DESCRIPTION
fix typo: It is not recommended to run t̶o̶ ̶ this version.